### PR TITLE
gh-22: add CLIProxyAPI operator targets to `Makefile` and document dual-service architecture in `README.md`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 TF_DIR := infra/terraform
 
-.PHONY: init plan deploy destroy logs status restart update open fmt bootstrap-state migrate-state
+.PHONY: init plan deploy destroy logs logs-cliproxy status status-cliproxy restart restart-cliproxy update open open-cliproxy fmt bootstrap-state migrate-state
 
 # Terraform requires >= 1.11.0 for write-only secret attributes.
 # Install the latest via: brew upgrade terraform
@@ -26,42 +26,84 @@ destroy: ## Destroy all infrastructure
 	@echo ""
 	cd $(TF_DIR) && terraform destroy
 
-update: ## Deploy a specific image version: make update IMAGE_TAG=v6.9.7
-	@[ -n "$(IMAGE_TAG)" ] || (echo "Usage: make update IMAGE_TAG=v6.9.7"; exit 1)
+update: ## Deploy a specific image version: make update IMAGE_TAG=main-stable
+	@[ -n "$(IMAGE_TAG)" ] || (echo "Usage: make update IMAGE_TAG=main-stable"; exit 1)
 	cd $(TF_DIR) && terraform apply -var="image_tag=$(IMAGE_TAG)"
 
-logs: ## Tail Cloud Run logs
+logs: ## Tail Cloud Run logs for LiteLLM
 	@gcloud run services logs read proxies-llm \
 		--project=$$(cd $(TF_DIR) && terraform output -raw gcp_project) \
 		--region=$$(cd $(TF_DIR) && terraform output -raw gcp_region) \
 		--limit=50
 
-status: ## Show Cloud Run service status
+logs-cliproxy: ## Tail Cloud Run logs for CLIProxyAPI
+	@gcloud run services logs read proxies-models \
+		--project=$$(cd $(TF_DIR) && terraform output -raw gcp_project) \
+		--region=$$(cd $(TF_DIR) && terraform output -raw gcp_region) \
+		--limit=50
+
+status: ## Show Cloud Run service status for LiteLLM
 	@gcloud run services describe proxies-llm \
 		--project=$$(cd $(TF_DIR) && terraform output -raw gcp_project) \
 		--region=$$(cd $(TF_DIR) && terraform output -raw gcp_region) \
 		--format="yaml(status)"
 
-restart: ## Force a new Cloud Run revision (picks up latest secret version)
+status-cliproxy: ## Show Cloud Run service status for CLIProxyAPI
+	@gcloud run services describe proxies-models \
+		--project=$$(cd $(TF_DIR) && terraform output -raw gcp_project) \
+		--region=$$(cd $(TF_DIR) && terraform output -raw gcp_region) \
+		--format="yaml(status)"
+
+restart: ## Force a new Cloud Run revision for LiteLLM
 	@gcloud run services update proxies-llm \
 		--project=$$(cd $(TF_DIR) && terraform output -raw gcp_project) \
 		--region=$$(cd $(TF_DIR) && terraform output -raw gcp_region) \
 		--no-traffic
 
-open: ## Open the management dashboard in a browser
+restart-cliproxy: ## Force a new Cloud Run revision for CLIProxyAPI
+	@gcloud run services update proxies-models \
+		--project=$$(cd $(TF_DIR) && terraform output -raw gcp_project) \
+		--region=$$(cd $(TF_DIR) && terraform output -raw gcp_region) \
+		--no-traffic
+
+open: ## Open the LiteLLM admin dashboard in a browser
 	@open $$(cd $(TF_DIR) && terraform output -raw dashboard_url)
 
-bootstrap-state: ## Create the GCS state bucket (run once, before 'make init')
+open-cliproxy: ## Open the CLIProxyAPI management UI in a browser
+	@open $$(cd $(TF_DIR) && terraform output -raw cliproxy_custom_url)/management.html
+
+bootstrap-state: ## Create the GCS state bucket with CMEK (run once, before 'make init')
 	@[ -n "$(GCP_PROJECT)" ] || (echo "Usage: make bootstrap-state GCP_PROJECT=your-project-id"; exit 1)
+	@echo "Enabling Cloud KMS API..."
+	@gcloud services enable cloudkms.googleapis.com --project=$(GCP_PROJECT)
+	@echo "Creating state bucket..."
 	@gcloud storage buckets create gs://$(GCP_PROJECT)-terraform-state \
 		--project=$(GCP_PROJECT) \
 		--location=us-central1 \
 		--uniform-bucket-level-access
 	@gcloud storage buckets update gs://$(GCP_PROJECT)-terraform-state --versioning
+	@echo "Creating KMS keyring and key..."
+	@gcloud kms keyrings create terraform-state \
+		--location=us-central1 \
+		--project=$(GCP_PROJECT)
+	@gcloud kms keys create state-encryption \
+		--location=us-central1 \
+		--keyring=terraform-state \
+		--purpose=encryption \
+		--rotation-period=90d \
+		--next-rotation-time=$$(date -u -v+90d +%Y-%m-%dT%H:%M:%SZ) \
+		--project=$(GCP_PROJECT)
+	@echo "Authorizing GCS service agent for CMEK..."
+	@gcloud storage service-agent \
+		--project=$(GCP_PROJECT) \
+		--authorize-cmek=projects/$(GCP_PROJECT)/locations/us-central1/keyRings/terraform-state/cryptoKeys/state-encryption
+	@echo "Applying CMEK to state bucket..."
+	@gcloud storage buckets update gs://$(GCP_PROJECT)-terraform-state \
+		--default-encryption-key=projects/$(GCP_PROJECT)/locations/us-central1/keyRings/terraform-state/cryptoKeys/state-encryption
 	@cp $(TF_DIR)/backend.tfbackend.example $(TF_DIR)/backend.tfbackend
 	@sed -i '' 's/YOUR_GCP_PROJECT_ID/$(GCP_PROJECT)/' $(TF_DIR)/backend.tfbackend
 	@echo ""
-	@echo "State bucket created and backend.tfbackend written."
+	@echo "State bucket created with CMEK encryption and backend.tfbackend written."
 	@echo "Now run: make init"
 
 migrate-state: ## Migrate existing local state to the GCS backend

--- a/README.md
+++ b/README.md
@@ -1,25 +1,84 @@
 # proxies
 
-A shared LLM API proxy at `llm.proxies.of.achyuth.dev`. If you've been given a key, here's how to point Claude Code at it.
+Two-layer LLM proxy on Cloud Run: [CLIProxyAPI](https://github.com/router-for-me/CLIProxyAPI) handles OAuth-based model access, [LiteLLM](https://github.com/BerriAI/litellm) sits in front with per-key model restrictions and spend tracking.
 
-## Setup
+| Service | Domain | Purpose |
+|---------|--------|---------|
+| LiteLLM | `llm.proxies.of.achyuth.dev` | API gateway with virtual keys, model access control, and admin UI |
+| CLIProxyAPI | `models.proxies.of.achyuth.dev` | Upstream model provider (Claude via OAuth, Fireworks, etc.) |
 
-Edit `~/.claude/settings.json` (create it if it doesn't exist) and add the following `env` block:
+## Architecture
+
+```
+Client (Claude Code, curl, etc.)
+  │
+  ▼
+LiteLLM (llm.proxies.of.achyuth.dev)
+  │  per-key model restrictions, spend tracking, admin UI
+  ▼
+CLIProxyAPI (models.proxies.of.achyuth.dev)
+  │  OAuth token management, provider routing
+  ├──► Anthropic (Claude models via OAuth)
+  └──► Fireworks AI (Kimi K2.5, etc.)
+```
+
+## Client setup
+
+Edit `~/.claude/settings.json` and add:
 
 ```json
 {
   "env": {
     "ANTHROPIC_BASE_URL": "https://llm.proxies.of.achyuth.dev",
-    "ANTHROPIC_AUTH_TOKEN": "sk-your-key-here",
-    "ENABLE_TOOL_SEARCH": "true"
+    "ANTHROPIC_AUTH_TOKEN": "sk-your-key-here"
   }
 }
 ```
 
-Replace `sk-your-key-here` with the key you were given. `ENABLE_TOOL_SEARCH` is required for MCP tool search to work when using a custom base URL.
+Replace `sk-your-key-here` with the key you were given.
 
 **File location:**
 - macOS / Linux: `~/.claude/settings.json`
 - Windows: `%USERPROFILE%\.claude\settings.json`
 
-That's it. Restart Claude Code and it will route through the proxy automatically.
+## Infrastructure
+
+Everything runs on GCP Cloud Run, managed by Terraform.
+
+### Prerequisites
+
+- Terraform >= 1.11.0
+- `gcloud` CLI (authenticated)
+- A Cloudflare zone for DNS
+- A Neon PostgreSQL database (shared by both services)
+
+### First-time setup
+
+```sh
+cp infra/terraform/terraform.tfvars.example infra/terraform/terraform.tfvars
+# Fill in your values
+
+make bootstrap-state GCP_PROJECT=your-project-id
+make init
+make deploy
+```
+
+### Day-to-day
+
+```sh
+make plan              # Preview changes
+make deploy            # Apply changes
+make logs              # LiteLLM logs
+make logs-cliproxy     # CLIProxyAPI logs
+make status            # LiteLLM service status
+make status-cliproxy   # CLIProxyAPI service status
+make restart           # Force new LiteLLM revision
+make restart-cliproxy  # Force new CLIProxyAPI revision
+make open              # Open LiteLLM admin dashboard
+make open-cliproxy     # Open CLIProxyAPI management UI
+```
+
+### Configuration
+
+- **LiteLLM** models and keys are managed through the admin UI at `/ui` or via the `/model/new` and `/key/generate` API endpoints. State is stored in PostgreSQL.
+- **CLIProxyAPI** providers and OAuth tokens are managed through the management UI at `/management.html`. State is persisted to PostgreSQL via `PGSTORE_DSN`.


### PR DESCRIPTION
## Changes

Adds `logs-cliproxy`, `status-cliproxy`, `restart-cliproxy`, and `open-cliproxy` Makefile targets for the new CLIProxyAPI service. Updates existing LiteLLM targets with clearer descriptions. Expands `bootstrap-state` to create a KMS keyring and key for state bucket CMEK encryption, matching the `storage.tf` changes in #21.

Rewrites `README.md` with a service table, ASCII architecture diagram, updated client setup, full day-to-day command reference for both services, and a configuration section documenting how each service's state is managed.

Closes #22

## Testing

- [ ] `make help` shows new CLIProxyAPI targets
- [ ] `README.md` renders correctly in GitHub

## Checklist

- [x] Self-reviewed diff
- [x] No debugging artifacts
- [x] Commit history is clean
